### PR TITLE
[FEA] update CMake, expand clang version list, build images in parallel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 Dockerfile.*
+docker-compose.yml

--- a/buildall.py
+++ b/buildall.py
@@ -8,7 +8,7 @@ gcc_versions = list(range(7, 11 + 1))
 prologue = """
 FROM ubuntu:20.04
 
-ENV DEBIAN_FRONTEND=noninteractive
+ARG DEBIAN_FRONTEND=noninteractive
 """
 
 install_base = """

--- a/buildall.py
+++ b/buildall.py
@@ -9,6 +9,7 @@ prologue = """
 FROM ubuntu:20.04
 
 ARG DEBIAN_FRONTEND=noninteractive
+ARG CMAKE_VERSION=3.24.1-0kitware1ubuntu20.04.1
 """
 
 install_base = """
@@ -25,7 +26,9 @@ RUN set -xe; \\
     apt-get -y update; \\
     # Install generic build tools & python
     apt-get -y install --no-install-recommends \\
-        cmake pkg-config make \\
+        pkg-config make \\
+        cmake=$CMAKE_VERSION \\
+        cmake-data=$CMAKE_VERSION \\
         python3 python3-pip python3-setuptools \\
         ; \\
     # Cleanup apt packages

--- a/buildall.py
+++ b/buildall.py
@@ -98,7 +98,7 @@ def _get_compiler_text(compilers, extra_packages=""):
     return f"""
 # Clang and tools
 RUN set -xe; \\
-    {pre_install}
+    {pre_install} \\
     apt-get -y update; \\
     apt-get -y install --no-install-recommends \\
         {packages} \\

--- a/buildall.py
+++ b/buildall.py
@@ -2,7 +2,7 @@
 
 import subprocess
 
-clang_versions = list(range(7, 13 + 1))
+clang_versions = list(range(7, 15 + 1))
 gcc_versions = list(range(7, 11 + 1))
 
 prologue = """
@@ -43,10 +43,6 @@ COPY entrypoint.py /usr/local/bin/entrypoint.py
 ENTRYPOINT ["/usr/local/bin/entrypoint.py"]
 """
 
-clang_preinstall = """wget -qO - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -; \\
-    apt-add-repository -y -n "deb http://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs)-13 main"; \\
-"""
-
 
 def _gen_alternatives(alts):
     """Generate alternatives strings; takes in a list of pairs (alias-name, actual-name)"""
@@ -69,7 +65,10 @@ def _get_compiler_text(compilers, extra_packages=""):
 
     if "clang" in compilers:
         v = compilers["clang"]
-        pre_install = clang_preinstall
+        llvm_dev_ver = v if v > 13 else 13
+        pre_install = f"""wget -qO - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -; \\
+    apt-add-repository -y -n "deb http://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs)-{llvm_dev_ver} main"; \\
+"""
         packages = f"clang++-{v} libc++-{v}-dev libc++abi-{v}-dev clang-tidy-{v} clang-format-{v}"
         alts = [
             ("clang", f"clang-{v}"),

--- a/buildall.py
+++ b/buildall.py
@@ -138,6 +138,7 @@ def main():
   main:
     image: lucteo/action-cxx-toolkit.main
     build:
+      context: .
       dockerfile: Dockerfile.main
 """)
         for v in gcc_versions:
@@ -145,6 +146,7 @@ def main():
   gcc{v}:
     image: lucteo/action-cxx-toolkit.gcc{v}
     build:
+      context: .
       dockerfile: Dockerfile.gcc{v}
 """)
         for v in clang_versions:
@@ -152,6 +154,7 @@ def main():
   clang{v}:
     image: lucteo/action-cxx-toolkit.clang{v}
     build:
+      context: .
       dockerfile: Dockerfile.clang{v}
 """)
 

--- a/uploadall.sh
+++ b/uploadall.sh
@@ -2,18 +2,4 @@
 
 set -xe
 
-docker push lucteo/action-cxx-toolkit.main
-
-docker push lucteo/action-cxx-toolkit.gcc7
-docker push lucteo/action-cxx-toolkit.gcc8
-docker push lucteo/action-cxx-toolkit.gcc9
-docker push lucteo/action-cxx-toolkit.gcc10
-docker push lucteo/action-cxx-toolkit.gcc11
-
-docker push lucteo/action-cxx-toolkit.clang7
-docker push lucteo/action-cxx-toolkit.clang8
-docker push lucteo/action-cxx-toolkit.clang9
-docker push lucteo/action-cxx-toolkit.clang10
-docker push lucteo/action-cxx-toolkit.clang11
-docker push lucteo/action-cxx-toolkit.clang12
-docker push lucteo/action-cxx-toolkit.clang13
+docker-compose push


### PR DESCRIPTION
This PR...

* updates CMake to `v3.24.1`
* expands the list of clang versions to 15
* uses `docker-compose` to build the images in parallel to speed up local dev

Now `buildall.py` generates the Dockerfiles with a `docker-compose.yml` file and invokes `docker-compose build --parallel` for each compiler type. `uploadall.sh` is now essentially an alias for `docker-compose push`:

![Screenshot_2022-08-29_23-32-37](https://user-images.githubusercontent.com/178183/187367257-8f014e0d-3a18-49c9-a188-137358e823c7.png)