### PR TITLE
Add `nvcc` and `nvc++` images

### DIFF
--- a/buildall.py
+++ b/buildall.py
@@ -51,7 +51,7 @@ def _gen_alternatives(alts):
     """Generate alternatives strings; takes in a list of pairs (alias-name, actual-name)"""
     res = ""
     for (alias, actual) in alts:
-        rule = f"/usr/bin/{alias} {alias} /usr/bin/{actual}"
+        rule = f"/usr/bin/{alias} {alias} {actual}"
         if not res:
             res = f"update-alternatives --install {rule} 100 "
         else:
@@ -74,16 +74,17 @@ def _get_compiler_text(compilers, extra_packages=""):
 """
         packages = f"clang++-{v} libc++-{v}-dev libc++abi-{v}-dev clang-tidy-{v} clang-format-{v}"
         alts = [
-            ("clang", f"clang-{v}"),
-            ("clang-format", f"clang-format-{v}"),
-            ("clang-tidy", f"clang-tidy-{v}"),
+            ("clang", f"/usr/bin/clang-{v}"),
+            ("clang-format", f"/usr/bin/clang-format-{v}"),
+            ("clang-tidy", f"/usr/bin/clang-tidy-{v}"),
+            ("run-clang-tidy", f"/usr/lib/llvm-{v}/bin/run-clang-tidy"),
         ]
         # Also add alias from gcc to clang
         if "gcc" not in compilers:
             alts.extend(
                 [
-                    ("gcc", f"clang-{v}"),
-                    ("g++", f"clang++-{v}"),
+                    ("gcc", f"/usr/bin/clang-{v}"),
+                    ("g++", f"/usr/bin/clang++-{v}"),
                 ]
             )
 
@@ -92,8 +93,8 @@ def _get_compiler_text(compilers, extra_packages=""):
         packages += f" g++-{v}"
         alts.extend(
             [
-                ("gcc", f"gcc-{v}"),
-                ("g++", f"g++-{v}"),
+                ("gcc", f"/usr/bin/gcc-{v}"),
+                ("g++", f"/usr/bin/g++-{v}"),
             ]
         )
 

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -316,7 +316,7 @@ def configure_cmake_build(compilerVer, envSetCmd, hasConan):
         PropertyPrint('Running clang-tidy', yesno(True))()
         flags = param('INPUT_CLANGTIDYFLAGS', '')
         buildCmds.add(Command(f'if [ -f "{srcDir}/.clang-tidy" ]; then cp --verbose "{srcDir}/.clang-tidy" {buildDir}; fi'))
-        buildCmds.add(Command(f'/usr/lib/llvm-13/bin/run-clang-tidy -p . {flags}'))
+        buildCmds.add(Command(f'run-clang-tidy -p . {flags}'))
 
     # Generate a test command to be used later
     ctest_flags = param('INPUT_CTESTFLAGS', '')


### PR DESCRIPTION
* Adds images with `gcc` + `nvcc` for CUDA 11.7.1 and 11.8
* Adds images with `gcc` + `nvc++` for CUDA 11.7 (latest available image)
* Fixes a bug I introduced in #1 where `run-clang-tidy` path was wrong because clang version was updated (fixed by adding `run-clang-tidy` to the list of generated alternatives)

I can't recall whether the NVCHPC images require a login to the nvcr.io container registry. I already have my NVIDIA creds on all my machines, so I couldn't test the error case. Let me know if this a blocker for you @lucteo!

<details><summary>Expand here to see new generated dockerfiles list</summary><a target="_blank" rel="noopener noreferrer nofollow" href="https://user-images.githubusercontent.com/178183/196283366-f2bf40a1-85f5-439a-8172-ecadee07adba.png"><img src="https://user-images.githubusercontent.com/178183/196283366-f2bf40a1-85f5-439a-8172-ecadee07adba.png" alt="image" style="max-width: 100%;"></a></details>
